### PR TITLE
README: Fix indentation typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,5 +104,5 @@ In order to be able to replicate the functionality seen in native applications, 
 
  * provide a means for scripts to be notified if the connection type changes. This is to allow developers to make dynamic changes to the DOM and/or inform the user that network connection type has changed.
 
- ## Acknowledgments
- Huge thanks to Yoav Weiss, Mathias Bynens, Tobie Langel, and Michael Hung fo.
+## Acknowledgments
+Huge thanks to Yoav Weiss, Mathias Bynens, Tobie Langel, and Michael Hung fo.


### PR DESCRIPTION
The acknowledgments were incorrectly listed as part of the last bullet point under “Requirements”.
